### PR TITLE
Make compatible with GHC 7.10

### DIFF
--- a/Data/ByteString/Plain.hs
+++ b/Data/ByteString/Plain.hs
@@ -22,7 +22,7 @@ module Data.ByteString.Plain (
     , length
     ) where
 
-import           Control.DeepSeq (NFData)
+import           Control.DeepSeq (NFData (..))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B
 import           Data.Hashable (Hashable(hashWithSalt))
@@ -135,7 +135,7 @@ length (PBS mbarr#) = I# (sizeofMutableByteArray# mbarr#)
 {-# INLINE length #-}
 
 -- WHNF == NF
-instance NFData ByteString
+instance NFData ByteString where rnf x = seq x ()
 
 -- the following instances are implement via strict 'B.ByteString's;
 -- In the future "native" implementations shall be provided if they

--- a/bytestring-plain.cabal
+++ b/bytestring-plain.cabal
@@ -35,10 +35,10 @@ library
   default-language:    Haskell2010
   exposed-modules:     Data.ByteString.Plain
   other-extensions:    DeriveDataTypeable, MagicHash, UnliftedFFITypes
-  build-depends:       base       >= 4.6   && <4.8,
+  build-depends:       base       >= 4.6   && <4.9,
                        bytestring >= 0.10  && <0.11,
-                       ghc-prim   >= 0.3   && <0.4,
-                       deepseq    >= 1.2   && <1.4,
+                       ghc-prim   >= 0.3   && <0.5,
+                       deepseq    >= 1.2   && <1.5,
                        hashable   >= 1.1.1 && <1.3
   ghc-options:         -Wall
 


### PR DESCRIPTION
This commit tries to update the library to be compatible with GHC 7.10, but doesn't bump up the version leaving it to be updated by the maintainer himself.
