### PR TITLE
Provide "native" implemenations for 'Eq' and 'Ord' instances

### DIFF
--- a/Data/ByteString/Plain.hs
+++ b/Data/ByteString/Plain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DeriveDataTypeable       #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE MagicHash                #-}
@@ -150,7 +151,7 @@ instance Eq ByteString where
 
 instance Ord ByteString where
     compare (PBS mbarr1#) (PBS mbarr2#) =
-      B.accursedUnutterablePerformIO $ do
+      inlinePerformIO $ do
         let len1 = I# (sizeofMutableByteArray# mbarr1#)
             len2 = I# (sizeofMutableByteArray# mbarr2#)
             p1 = byteArrayContents# (unsafeCoerce# mbarr1#)
@@ -172,6 +173,19 @@ instance Show ByteString where
 
 instance Read ByteString where
     readsPrec p str = [ (fromStrict x, y) | (x, y) <- readsPrec p str ]
+
+-- ---------------------------------------------------------------------
+--
+-- Utils
+--
+
+inlinePerformIO :: IO a -> a
+#if MIN_VERSION_bytestring(0,10,6)
+inlinePerformIO = B.accursedUnutterablePerformIO
+#else
+inlinePerformIO = B.inlinePerformIO
+#endif
+{-# INLINE inlinePerformIO #-}
 
 -- ---------------------------------------------------------------------
 --

--- a/Data/ByteString/Plain.hs
+++ b/Data/ByteString/Plain.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE MagicHash, DeriveDataTypeable, UnliftedFFITypes #-}
+{-# LANGUAGE DeriveDataTypeable       #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE MagicHash                #-}
+{-# LANGUAGE UnliftedFFITypes         #-}
 
 -- |
 -- Stability   : experimental
@@ -22,16 +25,17 @@ module Data.ByteString.Plain (
     , length
     ) where
 
-import           Control.DeepSeq (NFData(rnf))
-import qualified Data.ByteString as B
+import           Control.DeepSeq          (NFData (rnf))
+import qualified Data.ByteString          as B
 import qualified Data.ByteString.Internal as B
-import           Data.Hashable (Hashable(hashWithSalt))
+import           Data.Hashable            (Hashable (hashWithSalt))
 import           Data.Typeable            (Typeable)
+import           Foreign.C.Types
 import           GHC.ForeignPtr
 import           GHC.Prim
 import           GHC.Types
-import           Prelude hiding (length, null)
-import           System.IO.Unsafe (unsafePerformIO)
+import           Prelude                  hiding (length, null)
+import           System.IO.Unsafe         (unsafePerformIO)
 
 -- |Compact heap representation a (strict) 'B.ByteString' can be (un)wrapped to/from.
 --
@@ -141,11 +145,21 @@ instance NFData ByteString where rnf x = seq x ()
 -- In the future "native" implementations shall be provided if they
 -- result being faster.
 instance Eq ByteString where
-    x == y  = toStrict x == toStrict y
+    x == y  = x `compare` y == EQ
     {-# INLINE (==) #-}
 
 instance Ord ByteString where
-    compare x y  = compare (toStrict x) (toStrict y)
+    compare (PBS mbarr1#) (PBS mbarr2#) =
+      B.accursedUnutterablePerformIO $ do
+        let len1 = I# (sizeofMutableByteArray# mbarr1#)
+            len2 = I# (sizeofMutableByteArray# mbarr2#)
+            p1 = byteArrayContents# (unsafeCoerce# mbarr1#)
+            p2 = byteArrayContents# (unsafeCoerce# mbarr2#)
+
+        i <- memcmp p1 p2 (min len1 len2)
+        return $! case i `compare` 0 of
+          EQ  -> len1 `compare` len2
+          x   -> x
     {-# INLINE compare #-}
 
 instance Hashable ByteString where
@@ -158,3 +172,14 @@ instance Show ByteString where
 
 instance Read ByteString where
     readsPrec p str = [ (fromStrict x, y) | (x, y) <- readsPrec p str ]
+
+-- ---------------------------------------------------------------------
+--
+-- Standard C functions
+--
+
+foreign import ccall unsafe "string.h memcmp" c_memcmp
+    :: Addr# -> Addr# -> CSize -> IO CInt
+
+memcmp :: Addr# -> Addr# -> Int -> IO CInt
+memcmp p q s = c_memcmp p q (fromIntegral s)


### PR DESCRIPTION
I've "played" a little bit further with your library trying to follow
your suggestions in one of your comments:

```
-- the following instances are implement via strict 'B.ByteString's;
-- In the future "native" implementations shall be provided if they
-- result being faster.
```

(And sorry in advance for some stylish-haskell format changes, I left them in
since they are not that much intrusive)

This commit provides "native" implemenations for 'Eq' and 'Ord'
instances in order to avoid the overhead of having to convert the
plain-bytestrings into strict bytestrings first...

A simple benchmark with a random 32-bytes test-string suggests
that this can indeed improve the performance a little bit:

```
-----------------------------------------------------------------

benchmarking g1/compareOld
time                 25.47 ns   (25.29 ns .. 25.72 ns)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 25.36 ns   (25.31 ns .. 25.46 ns)
std dev              225.0 ps   (118.0 ps .. 380.7 ps)

benchmarking g1/compareNew
time                 17.79 ns   (17.76 ns .. 17.84 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.87 ns   (17.81 ns .. 17.98 ns)
std dev              256.7 ps   (134.4 ps .. 412.4 ps)
variance introduced by outliers: 18% (moderately inflated)

benchmarking g1/equalsOld
time                 27.17 ns   (27.15 ns .. 27.19 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.18 ns   (27.16 ns .. 27.23 ns)
std dev              110.7 ps   (57.02 ps .. 202.1 ps)

benchmarking g1/equalsNew
time                 17.16 ns   (17.15 ns .. 17.18 ns)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.20 ns   (17.19 ns .. 17.23 ns)
std dev              67.37 ps   (58.31 ps .. 79.46 ps)

----------------------------------------------------------------
```
